### PR TITLE
Fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk --no-cache upgrade \
     "https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${OVERLAY_ARCH}.tar.gz" \
     && curl -o /tmp/s6-overlay.tar.gz.sig -L \
     "https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${OVERLAY_ARCH}.tar.gz.sig" \
-    && curl https://keybase.io/justcontainers/key.asc | gpg --import \
+    && gpg --keyserver pgp.surfnet.nl  --recv-keys 6101B2783B2FD161 \
     && gpg --verify /tmp/s6-overlay.tar.gz.sig /tmp/s6-overlay.tar.gz \
     && tar xfz /tmp/s6-overlay.tar.gz -C / \
     && apk del gnupg \


### PR DESCRIPTION
Previously the key was being downloaded and then imported, now just query the server for the key.